### PR TITLE
カテゴリの表示を名前に変更

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -41,7 +41,7 @@
             %td
               = link_to '#' do
                 %div 
-                  = @product.category_id
+                  = @product.category.name
               = link_to '#' do
                 .item-detail-table-sub-category
                   %i.fas.fa-chevron-right


### PR DESCRIPTION
#  what
カテゴリの表示を名前に変更

# why
id表示だとユーザーに伝わらない為。