### PR TITLE
取引中のパンくずリスト作成

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -47,8 +47,12 @@
               = fa_icon 'check', class: 'icon'
               .nav-text やることリスト
             = link_to  mypage_user_path(current_user), class: 'link-none' do
-              = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", class: 'user-icon'
-              .nav-text マイページ 
+              - if current_user.avator.blank?
+                = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", class: 'user-icon'
+              - else
+                = image_tag "#{current_user.avator}", class: 'user-icon'
+              .nav-text マイページ
+
         - else 
           .mercari__head__bottom__new
             = link_to '新規会員登録', session0_signup_index_path, class: 'mercari__head__bottom__signup'

--- a/app/views/users/buy.html.haml
+++ b/app/views/users/buy.html.haml
@@ -1,4 +1,7 @@
-= render 'shared/header'  
+= render 'shared/header'
+- breadcrumb :buy
+= render "layouts/breadcrumbs"
+
 .body
   .mypage
     = render 'side-bar'

--- a/app/views/users/negotiation.html.haml
+++ b/app/views/users/negotiation.html.haml
@@ -1,4 +1,7 @@
-= render 'shared/header'  
+= render 'shared/header'
+- breadcrumb :negotiation
+= render "layouts/breadcrumbs"
+
 .body
   .mypage
     = render 'side-bar'
@@ -24,5 +27,6 @@
                   .bottom-text
                     %span.negotiation 取引中
                 .content-arrow
-                  = fa_icon 'chevron-right', class: 'icon-right'        
+                  = fa_icon 'chevron-right', class: 'icon-right'
+                       
 = render 'shared/footer'   

--- a/app/views/users/sell.html.haml
+++ b/app/views/users/sell.html.haml
@@ -1,4 +1,7 @@
-= render 'shared/header'  
+= render 'shared/header'
+- breadcrumb :sell
+= render "layouts/breadcrumbs"
+
 .body
   .mypage
     = render 'side-bar'

--- a/app/views/users/seller.html.haml
+++ b/app/views/users/seller.html.haml
@@ -1,4 +1,7 @@
-= render 'shared/header'  
+= render 'shared/header'
+- breadcrumb :seller
+= render "layouts/breadcrumbs"
+
 .body
   .mypage
     = render 'side-bar'

--- a/app/views/users/sold.html.haml
+++ b/app/views/users/sold.html.haml
@@ -1,4 +1,7 @@
-= render 'shared/header'  
+= render 'shared/header'
+- breadcrumb :sold
+= render "layouts/breadcrumbs"
+
 .body
   .mypage
     = render 'side-bar'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -26,6 +26,31 @@ crumb :logout do
   parent :mypage
 end
 
+crumb :seller do
+  link "出品した商品 - 出品中", seller_users_path(current_user)
+  parent :mypage
+end
+
+crumb :negotiation do
+  link "出品した商品 - 取引中", negotiation_users_path(current_user)
+  parent :mypage
+end
+
+crumb :sell do
+  link "出品した商品 - 売却済", sell_users_path(current_user) 
+  parent :mypage
+end
+
+crumb :buy do
+  link "購入した商品 - 取引中", buy_users_path(current_user)
+  parent :mypage
+end
+
+crumb :sold do
+  link "購入した商品 -過去の取引", sold_users_path(current_user)
+  parent :mypage
+end
+
 crumb :categories do
   link "カテゴリ一覧", categories_path
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2019_10_29_054040) do
+
   create_table "brandgroups", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false


### PR DESCRIPTION
# What
・breadcrumb.rbに追記
・取引中の全てのページにパンくずリストを反映
・ヘッダーにアバター画像が表示されるように条件分岐を追加

# Why
ユーザーが現在いるページを把握しやすくするため