### PR TITLE
アバター画像の即プレビューを実装

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -1,0 +1,20 @@
+$(function(){
+  $('.form').on('change', 'input[type="file"]', function(e) {
+    console.log(this);
+    var file = e.target.files[0],
+        reader = new FileReader(),
+        previewArea = $('.preview');
+
+    reader.onload = (function() {
+      return function(e) {
+        previewArea.empty();
+        previewArea.append($('<img>').attr({
+                  src: e.target.result,
+                  class: "preview"
+              }));
+      };
+    })
+    (file);
+    reader.readAsDataURL(file);
+  });
+});

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -239,7 +239,11 @@
         font-weight: 600;
         }
         .form{
-          // padding: 40px;
+          .avator-text{
+            text-align: center;
+            font-weight: 600;
+            color: $red;
+          }
           .form-top{
             max-height: 200px;
             background: url('https://www.mercari.com/jp/assets/img/mypage/user-bg.jpg?39195692;');
@@ -253,11 +257,20 @@
                 height: 60px;
                 width: 60px; 
                 position: absolute;
-                top: 60px;
+                top: 50px;
                 left: 150px;
               }
               .hidden{
                 display: none;
+              }
+              .preview{
+                border-radius: 50%;
+                height: 70px;
+                width: 70px; 
+                position: absolute;
+                top: 25px;
+                left: 70px;
+                z-index: 1;
               }
               .textarea{
                 padding: 10px 15px 10px;

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -11,14 +11,18 @@
         .top-text
           プロフィール
         .form
+          .avator-text 
+            アイコンをクリックしてアバター画像を登録
           = form_for @user, url: user_path(current_user.id), method: :patch do |f|
             .form-top
               .profile-image
                 = f.label :avator do
                   - if @user.avator.blank?
                     = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", class: 'user-icon'
+                    .preview
                   - else 
-                    = image_tag "#{@user.avator}", class: 'user-icon'  
+                    = image_tag "#{@user.avator}", class: 'user-icon'
+                    .preview
                   = f.file_field :avator, class: 'hidden'
 
                 = f.text_field :callout, placeholder: '例）AYAセール中', class: 'textarea'


### PR DESCRIPTION
# What
ユーザーの登録したいアバター画像をファイル選択と同時に表示する
プレビューを表示されたい場所を指定
ファイルが変更されたことを契機にイベント発火して、画像をappendする仕組み

# Why
ファイル選択時登録したい画像が表示されないと、ユーザーにとって不便なため