### PR TITLE
新規会員登録機能のビュー及びモデルのバリデーション編集

### DIFF
--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -25,7 +25,7 @@ $(document).on('ready page:load',function(){
       view_box.append(img);
       filereader.onload = function() {
         view_box.find('img').attr('src', filereader.result);
-        img_del(view_box);
+        img_del(view_box);      
       }
       filereader.readAsDataURL(fileprop);
         if(count >= 9){

--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,0 +1,7 @@
+.notification{
+  .alert{
+    background-color: $red;
+    color: $white;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/_modal.scss
+++ b/app/assets/stylesheets/_modal.scss
@@ -5,6 +5,7 @@
     top: 0;
     left: 0;
     display: none;
+    background: rgba(0, 0, 0, 0.3);
     z-index: 1;
     #modalWindow {
       width: 600px;

--- a/app/assets/stylesheets/_session.scss
+++ b/app/assets/stylesheets/_session.scss
@@ -86,6 +86,10 @@
           background-color: $red;
           padding: 3px;
         }
+        .alert-text{
+          font-weight: bold;
+          color: $red;
+        }
         .textarea{
           width: 310px;
           border-radius: 3px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import 'breadcrumbs';
 @import 'pagenaction';
 @import 'modal';
+@import 'flash';
 @import 'top';
 @import 'buy';
 @import 'show';

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -54,6 +54,7 @@ class SignupController < ApplicationController
       sign_in User.find(session[:id])
       redirect_to root_path
     else
+      flash[:alert] = '新規会員登録に失敗しました、お手数ですが再度ご登録下さい'
       redirect_to session0_signup_index_path
     end
   end

--- a/app/models/creditcard.rb
+++ b/app/models/creditcard.rb
@@ -1,3 +1,8 @@
 class Creditcard < ApplicationRecord
   belongs_to :user, optional: true
+  creditcard_check = /\A[0-9]+\z/
+  validates :credit_number, presence: true, length: { maximum: 20 }, format: { with: creditcard_check }, on: :create
+  validates :validity_month, presence: true, on: :create
+  validates :validity_day, presence: true, on: :create
+  validates :security_number, presence: true, length: { maximum: 4 }, format: { with: creditcard_check }, on: :create
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,7 +4,6 @@ class Profile < ApplicationRecord
 
   kana_check = /\A[ァ-ヶー－]+\z/
   tel_check = /(070|080|090)\d{8}|(070|080|090)-\d{4}-\d{4}|(０７０|０８０|０９０)[０-９]{8}|(０７０|０８０|０９０)-[０-９]{4}-[０-９]{4}/
-  # tel_check = /\A\d{11}\z/
   zipcode_check = /\A\d{3}[-]\d{4}\z/
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,11 +50,9 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :profile
 
   email_check = /\A[^@\s]+@[^@\s]+\z/
-  email_check =                 /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   password_check =              /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   validates :email,                 presence: true, uniqueness: { case_sensitive: false }, format: { with: email_check }, on: :create
-  validates :password,              presence: true, length: {minimum: 7, maximum: 128}, on: :create
-  validates :password_confirmation, presence: true, length: {minimum: 7, maximum: 128}, on: :create
-  # validates :nickname,              presence: true, length: {maximum: 20}
+  validates :password,              presence: true, length: {minimum: 7, maximum: 128}, format: { with: password_check }, on: :create
+  validates :password_confirmation, presence: true, length: {minimum: 7, maximum: 128}, format: { with: password_check }, on: :create
   validates :nickname,              presence: true, on: :create
 end

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key,value|
+    =content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,4 +10,5 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    = render partial: 'layouts/notifications'
     = yield

--- a/app/views/signup/session0.html.haml
+++ b/app/views/signup/session0.html.haml
@@ -2,7 +2,7 @@
   .header
     = link_to root_path, class:'header-logo' do
       = image_tag '//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2296184308',class: 'header-logo'
-    
+
   .new-session-main
     .new-session-main__top
       新規会員登録

--- a/app/views/signup/session1.html.haml
+++ b/app/views/signup/session1.html.haml
@@ -45,14 +45,18 @@
             %span.top-red-text 必須
             %br/
             = f.text_field :email, placeholder: '例）PC携帯どちらでも可', class: 'textarea'
-          .field 
+          .field
             %label.top-text パスワード
             %span.top-red-text 必須
+            %br/
+            %label.alert-text 半角英数７文字以上で登録して下さい
             %br/
             = f.text_field :password, placeholder: '例）7文字以上', class: 'textarea'
           .field 
             %label.top-text パスワード(確認)
             %span.top-red-text 必須
+            %br/
+            %label.alert-text 半角英数７文字以上で登録して下さい
             %br/
             = f.text_field :password_confirmation, placeholder: '例）7文字以上', class: 'textarea'
 
@@ -69,8 +73,10 @@
                 = o.text_field :first_name, placeholder: '例）山田', class: 'textarea-mini'
                 = o.text_field :last_name, placeholder: '例）綾', class: 'textarea-mini'
             .field
-              %label.top-text お名前（全角）
+              %label.top-text お名前（カナ）
               %span.top-red-text 必須
+              %br/
+              %label.alert-text カタカナで登録して下さい
               %br/
               .field-mini
                 = o.text_field :first_kana, placeholder: '例）ヤマダ', class: 'textarea-mini'

--- a/app/views/signup/session2.html.haml
+++ b/app/views/signup/session2.html.haml
@@ -39,6 +39,8 @@
             .field
               %label.top-text 電話番号
               %br/
+              %label.alert-text 全角半角対応、ハイフンなしで登録して下さい
+              %br/
               = o.text_field :tel, placeholder: '例）携帯番号の入力', size: "40", class: 'textarea'
               
             .field

--- a/app/views/signup/session4.html.haml
+++ b/app/views/signup/session4.html.haml
@@ -47,11 +47,15 @@
                 %label.top-text お名前カナ
                 %span.top-red-text 必須
                 %br/
+                %label.alert-text カタカナで登録して下さい
+                %br/
                 = o.text_field :first_kana, placeholder: '例）ヤマダ', class: 'textarea', value: "#{session[:first_kana]}"
                 = o.text_field :last_kana, placeholder: '例）アヤ', class: 'textarea', value: "#{session[:last_kana]}"
               .field
                 %label.top-text 郵便番号
                 %span.top-red-text 必須
+                %br/
+                %label.alert-text 半角数字ハイフンありで登録して下さい
                 %br/
                 = o.text_field :zipcode, placeholder: '例）123-4567', class: 'textarea'
               .field
@@ -80,6 +84,8 @@
               .field
                 %label.top-text 電話
                 %span.top-gary-text 任意
+                %br/
+                %label.alert-text 全角半角対応、ハイフンなしで登録して下さい
                 %br/
                 = o.text_field :tel, placeholder: '例）09012345678', class: 'textarea', value: "#{session[:tel]}"
 

--- a/app/views/signup/session5.html.haml
+++ b/app/views/signup/session5.html.haml
@@ -40,6 +40,8 @@
               %label.top-text カード番号
               %span.top-red-text 必須
               %br/
+              %label.alert-text 半角数字で登録して下さい
+              %br/
               = c.text_field :credit_number, placeholder: '例）半角数字のみ', class: 'textarea'
               %ul.signup-card-list
                 %li
@@ -75,6 +77,8 @@
             .field
               %label.top-text セキュリティカード
               %span.top-red-text 必須
+              %br/
+              %label.alert-text 半角数字3文字もしくは4文字で登録して下さい
               %br/
               = c.text_field :security_number, placeholder: '例）カード背面４桁もしくは3桁の番号', class: 'textarea'
               


### PR DESCRIPTION
# What
・登録ページに注意書き追加
・登録失敗時のフラッシュメッセージ追加
・モデルのバリデーションを変更
・その他誤記入訂正

# Why
新規会員登録時、ユーザーに再度登録させることを防ぐため
登録失敗を明示的に示すため